### PR TITLE
credentials are sensitive, mask them

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,5 +42,6 @@ template node['awscreds']['filename'] do
   owner "root"
   group "root"
   mode "0600"
+  senstive true
   variables :creds => creds, :default_creds => default_creds
 end


### PR DESCRIPTION
The `sensitive` attribute for the template resource should be used when
rendering files that contain sensitive information such as credentials so they
are not output in chef-client runs.
