### PR TITLE
attributes to custom the owner/group

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,6 @@
 default['awscreds']['filename'] = '/root/.aws/config'
+default['awscreds']['owner'] = 'root'
+default['awscreds']['group'] = 'root'
 default['awscreds']['vault_name'] = 'awscreds'
 default['awscreds']['vault_search'] = '*:*'
 default['awscreds']['default_profile'] = 'default'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,8 +39,8 @@ end
 
 template node['awscreds']['filename'] do
   source "config.erb"
-  owner "root"
-  group "root"
+  owner node['awscreds']['owner']
+  group node['awscreds']['group']
   mode "0600"
   senstive true
   variables :creds => creds, :default_creds => default_creds


### PR DESCRIPTION
As the filename location can be changed with an attribute, it is desirable to
make the owner and group customizable, since someone may wish to use a
different user than root for AWS access.

For example, a sensu plugin may need to read the credentials when running a
plugin as the `sensu` user. A Jenkins server may need to upload files to an S3
bucket as the `jenkins` user, etc.
